### PR TITLE
With speakers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backend/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 backend/node_modules
+backend/config.json
 rustaceans.db
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 backend/node_modules
+rustaceans.db

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,25 @@
+# Backend for rustaceans.org
+
+These scripts contain the API backend for rustaceans.org.
+
+## Development
+
+In order to develop rustaceans.org locally, follow these steps:
+
+1. Fork <https://github.com/nrc/rustaceans.org> (required to access it later)
+1. Create a personal access token: <https://github.com/settings/tokens>
+1. Create `config.json` with:
+
+```json
+{
+    "repo": "yourname/rustaceans.org",
+    "username": "yourname",
+    "token": "your-token"
+}
+```
+1. `npm install`
+1. `node init.js` (this will fill the database)
+1. `node rustacean.js` (this will start the API server on port 2345)
+1. In a second terminal, in the `rustaceans.org` directory: `python2 -m SimpleHTTPServer` (to have an http server serving these files)
+1. In `rustaceans.org/js/router.js` change API url to `http://localhost:2345/`
+1. Browse <http://localhost:8000/>

--- a/backend/call.js
+++ b/backend/call.js
@@ -10,7 +10,7 @@ exports.api_call = function(path, f, body, method) {
         path : path,
         method : method,
         body: body,
-        headers: {'user-agent': config.username, 'Authorization': 'token ' + config.token }
+        headers: {'user-agent': "rustaceans.org-init", 'Authorization': 'token ' + config.token }
     };
 
     var request = https.request(opts, function(response) {

--- a/backend/init.js
+++ b/backend/init.js
@@ -41,7 +41,7 @@ db.serialize(function() {
 db.close();
 
 function process_repo() {
-    call.api_call(config.repo + '/contents/data', function(json) {
+    call.api_call('/repos/' + config.repo + '/contents/data', function(json) {
         if (!json) {
             return;
         }

--- a/backend/init.js
+++ b/backend/init.js
@@ -22,7 +22,7 @@ db.serialize(function() {
     db.run("DROP TABLE people_channels", err_handler);
 
     // Create tables.
-    var table_people = fs.readFileSync("table_people.sql", { encoding: "UTF-8" })
+    var table_people = fs.readFileSync("table_people.sql", { encoding: "UTF-8" });
     db.run(table_people, err_handler);
     db.run("CREATE TABLE people_channels(person STRING, channel STRING)", err_handler);
 

--- a/backend/init.js
+++ b/backend/init.js
@@ -11,6 +11,7 @@ var sqlite = require("sqlite3");
 var call = require('./call.js');
 var user_mod = require("./user.js");
 var config = require('./config.json');
+var fs = require('fs');
 
 
 var db = new sqlite.Database("rustaceans.db");
@@ -21,18 +22,8 @@ db.serialize(function() {
     db.run("DROP TABLE people_channels", err_handler);
 
     // Create tables.
-    db.run("CREATE TABLE people(username STRING PRIMARY KEY,\
-                                name STRING,\
-                                irc STRING,\
-                                show_avatar BOOL,\
-                                email STRING,\
-                                discourse STRING,\
-                                reddit STRING,\
-                                twitter STRING,\
-                                blog STRING,\
-                                website STRING,\
-                                notes STRING,\
-                                blob STRING)", err_handler);
+    var table_people = fs.readFileSync("table_people.sql", { encoding: "UTF-8" })
+    db.run(table_people, err_handler);
     db.run("CREATE TABLE people_channels(person STRING, channel STRING)", err_handler);
 
     // Fill the tables from the repo.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "rustaceans-backend",
+  "version": "1.0.0",
+  "description": "Backend for Rustaceans.org",
+  "main": "rustaceans.js",
+  "dependencies": {
+    "async": "^2.1.2",
+    "marked": "^0.3.6",
+    "sqlite3": "^3.1.8"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "start": "node ./rustaceans.js",
+    "test": "true"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/backend/rustaceans.js
+++ b/backend/rustaceans.js
@@ -111,7 +111,7 @@ function search(search_str, res) {
 function speaker_search(search_str, res) {
     var db = new sqlite.Database("rustaceans.db");
     var search_str = "%" + search_str + "%";
-    db.all("SELECT * FROM people WHERE speaker = 1 AND (blob LIKE ? OR speaker_topics LIKE ?)", search_str, search_str, function(err, rows) {
+    db.all("SELECT * FROM people WHERE speaker = 1 AND (blob LIKE ? OR speaker_topics LIKE ? OR location LIKE ?)", search_str, search_str, search_str, function(err, rows) {
         if (err) {
             console.log("an error occured while searching for '" + search_str + "': " + err);
             make_response(res, [], db);

--- a/backend/rustaceans.js
+++ b/backend/rustaceans.js
@@ -144,7 +144,10 @@ var fields = [
     "twitter",
     "blog",
     "website",
-    "notes"
+    "notes",
+    "speaker",
+    "speaker_topics",
+    "location"
 ];
 
 
@@ -164,6 +167,14 @@ function make_user(user_row, channel_rows) {
         user['irc_channels'] = channel_rows.map(function(cr) { return cr.channel; });
     } else {
         user['irc_channels'] = [];
+    }
+
+    if (user_row.speaker == 't' || user_row.speaker == 1) {
+      user['speaker'] = true;
+    } else {
+      user['speaker'] = false;
+      delete user['speaker_topics'];
+      delete user['location'];
     }
     return user;
 }

--- a/backend/rustaceans.js
+++ b/backend/rustaceans.js
@@ -39,7 +39,7 @@ http.createServer(function (req, res) {
         });
     } else if (pathname =='/random') {
         // Return a random rustacean.
-        make_random_user(function (username) { get_user(username, res) } );
+        make_random_user(res, function (res, username) { get_user(username, res) } );
     } else {
         res.writeHead(404, {"Content-Type": "text/plain"});
         res.write("404 Not Found\n");
@@ -59,7 +59,7 @@ function get_channels(username, res, db, callback) {
     });
 }
 
-function make_random_user(mkusr) {
+function make_random_user(res, mkusr) {
     var db = new sqlite.Database("rustaceans.db");
     db.all('SELECT username FROM people;', function(err, rows) {
         if (err) {
@@ -69,7 +69,7 @@ function make_random_user(mkusr) {
         }
 
         if (!rows) {
-            console.log("no resuls while looking up usernames: " + err);
+            console.log("no results while looking up usernames: " + err);
             make_response(res, [], db);
             return;
         }

--- a/backend/rustaceans.js
+++ b/backend/rustaceans.js
@@ -61,21 +61,21 @@ function get_channels(username, res, db, callback) {
 
 function make_random_user(res, mkusr) {
     var db = new sqlite.Database("rustaceans.db");
-    db.all('SELECT username FROM people;', function(err, rows) {
+    db.get('SELECT username FROM people ORDER BY random() LIMIT 1;', function(err, user) {
         if (err) {
             console.log("an error occured while looking up usernames: " + err);
             make_response(res, [], db);
             return;
         }
 
-        if (!rows) {
+        if (!user) {
             console.log("no results while looking up usernames: " + err);
             make_response(res, [], db);
             return;
         }
 
-        var username = rows[Math.floor(Math.random() * rows.length)].username;
-        mkusr(username);
+        var username = user.username;
+        mkusr(res, username);
     });
 }
 

--- a/backend/table_people.sql
+++ b/backend/table_people.sql
@@ -1,0 +1,16 @@
+CREATE TABLE people(username STRING PRIMARY KEY,
+  name STRING,
+  irc STRING,
+  show_avatar BOOL,
+  email STRING,
+  discourse STRING,
+  reddit STRING,
+  twitter STRING,
+  blog STRING,
+  website STRING,
+  notes STRING,
+  blob STRING,
+  speaker BOOL DEFAULT false,
+  speaker_topics STRING,
+  location STRING
+)

--- a/backend/user.js
+++ b/backend/user.js
@@ -132,7 +132,7 @@ function insert_to_db(user_info, callback) {
         }
 
         db.run(strings, values, err_handler);
-    
+
         // irc channels go into a separate table
         var irc_string = 'INSERT INTO people_channels (person, channel) VALUES (?, ?);'
         var channels = user_info['irc_channels'];

--- a/backend/user.js
+++ b/backend/user.js
@@ -53,7 +53,9 @@ exports.process_user = function(user, pr_number, callback) {
 
 exports.process_many = function(users) {
     if (users.length > 0) {
-        exports.process_user(users[0], null, exports.process_many(users.slice(1)));
+        exports.process_user(users[0], null, function() {
+            exports.process_many(users.slice(1))
+        });
     }
 }
 

--- a/backend/user.js
+++ b/backend/user.js
@@ -74,6 +74,8 @@ var fields = [
     ["website", true],
     ["notes", true],
     ["speaker", true],
+    ["speaker_topics", true],
+    ["location", true]
 ];
 
 function insert_to_db(user_info, callback) {

--- a/backend/user.js
+++ b/backend/user.js
@@ -72,7 +72,8 @@ var fields = [
     ["twitter", true],
     ["blog", true],
     ["website", true],
-    ["notes", true]
+    ["notes", true],
+    ["speaker", true],
 ];
 
 function insert_to_db(user_info, callback) {

--- a/backend/user.js
+++ b/backend/user.js
@@ -10,7 +10,7 @@ exports.process_user = function(user, pr_number, callback) {
     if (!callback) {
         callback = function() {};
     }
-    call.api_call(config.repo + '/contents/data/' + user + '.json', function(json) {
+    call.api_call('/repos/' + config.repo + '/contents/data/' + user + '.json', function(json) {
         if (!json || json.type == undefined) {
             // Remove the user from the db.
             insert_to_db({'username': user}, function() {

--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -41,6 +41,16 @@
     <div class="clear"></div>
     {{#if notes}}<div class="notesrow"><span class="notes">{{{notes}}}</span></div>{{/if}}
     </div>
+    {{#if speaker}}
+    <div class="searchresult" class="clear">
+      <div class="name"><span class="name">Willing to speak!</span></div>
+      {{#if speaker_topics}}<div class="row"><span class="key">topics</span><span class="value">{{speaker_topics}}</span></div>{{/if}}
+      {{#if location}}<div class="row"><span class="key">location</span><span class="value">{{location}}</span></div>{{/if}}
+
+      {{#if username}}<div class="row"><span class="key">contact on</span><span class="value"><a href="https://github.com/rust-community/talks/issues/new?title=[Speaker%20Request]%20&body=Hey+@{{unbound username}}">github</a></span></div>{{/if}}
+      {{#if discourse}}<div class="row"><span class="key">contact on</span><span class="value"><a href="https://users.rust-lang.org/users/{{unbound discourse}}/">discourse</a></span></div>{{/if}}
+    </div>
+    {{/if}}
     {{/each}}
 
     {{partial "search_box"}}

--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -91,11 +91,13 @@
             <li>IRC on Moznet:
             <ul>
             <li><a href="irc://moznet/rust">#rust</a> is for all things Rust;</li>
+            <li><a href="irc://moznet/rust-beginners">#rust-beginners</a> is for anyone who needs help learning Rust. There are no stupid questions!;</li>
+            <li><a href="irc://moznet/rust-community">#rust-community</a> is where the community team and Rust meetup organizers hang out;</li>
             <li><a href="irc://moznet/rust-internals">#rust-internals</a> is for discussion of other Rust implementation topics;</li>
             <li><a href="irc://moznet/rustc">#rustc</a> is for discussion of the implementation of the Rust compiler;</li>
             <li><a href="irc://moznet/rust-libs">#rust-lang</a> is for discussion of the design of the Rust language;</li>
             <li><a href="irc://moznet/rust-libs">#rust-libs</a> is for discussion of the implementation of the Rust standard libraries;</li>
-            <li><a href="irc://moznet/rust-libs">#rust-tools</a> is for discussion of Rust tools;</li>
+            <li><a href="irc://moznet/rust-tools">#rust-tools</a> is for discussion of Rust tools;</li>
             <li><a href="irc://moznet/rust-gamedev">#rust-gamedev</a> is for people doing game development in Rust;</li>
             <li><a href="irc://moznet/rust-crypto">#rust-crypto</a> is for discussion of cryptography in Rust;</li>
             <li><a href="irc://moznet/rust-osdev">#rust-osdev</a> is for people doing OS development in Rust;</li>

--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -23,6 +23,14 @@
     {{input type="text" placeholder="search" action="search" on="enter" class="searchbox"}}
     </p>
     <p class="searchnotes">(by name, irc nick, username for Reddit, GitHub, Discourse, etc.)</p>
+    <p class="searchnotes">Looking for a speaker? <a href="#speaker-search">Search here.</a></p>
+</script>
+
+<script type="text/x-handlebars" data-template-name="_speaker_search_box">
+    <p class="pitch">
+        Search for a Rust speaker:
+    {{input type="text" placeholder="speaker" action="speaker" on="enter" class="searchbox"}}
+    </p>
 </script>
 
 <script type="text/x-handlebars" data-template-name="_results">
@@ -61,6 +69,10 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="search">
+{{partial "results"}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="speaker">
 {{partial "results"}}
 </script>
 
@@ -121,6 +133,8 @@
             </li>
         </ul>
     </p>
+
+    <div id="speaker-search" class="headsearch">{{partial "speaker_search_box"}}</div>
 </script>
 
 </body>

--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -31,6 +31,7 @@
         Search for a Rust speaker:
     {{input type="text" placeholder="speaker" action="speaker" on="enter" class="searchbox"}}
     </p>
+    <p class="searchnotes">(by name, topic or location)</p>
 </script>
 
 <script type="text/x-handlebars" data-template-name="_results">

--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -57,6 +57,8 @@
 
       {{#if username}}<div class="row"><span class="key">contact on</span><span class="value"><a href="https://github.com/rust-community/talks/issues/new?title=[Speaker%20Request]%20&body=Hey+@{{unbound username}}">github</a></span></div>{{/if}}
       {{#if discourse}}<div class="row"><span class="key">contact on</span><span class="value"><a href="https://users.rust-lang.org/users/{{unbound discourse}}/">discourse</a></span></div>{{/if}}
+      <br>
+      <p class="searchnotes">In order to contact the Rustacean, please open an issue or sent a DM on users.rust-lang.org</p>
     </div>
     {{/if}}
     {{/each}}

--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -41,7 +41,7 @@
     {{#if name}}<div class="name"><span class="name">{{#link-to 'people' username}}{{name}}{{/link-to}}</span></div>{{/if}}
     <div class="row"><span class="key">GitHub username</span><span class="value"><a href="https://github.com/{{unbound username}}">{{username}}</a></span></div>
     {{#if irc}}<div class="row"><span class="key">irc nick</span><span class="value"><span class="irc-nick">{{irc}}</span>{{#if irc_channels}} on {{#each irc_channels}} <a href="irc://moznet/{{unbound this}}">#{{this}}</a> {{/each}}{{/if}}</span></div>{{/if}}
-    {{#if discourse}}<div class="row"><span class="key">discourse username</span><span class="value"><a href="http://discuss.rust-lang.org/users/{{unbound discourse}}">{{discourse}}</a></span></div>{{/if}}
+    {{#if discourse}}<div class="row"><span class="key">discourse username</span><span class="value"><a href="http://users.rust-lang.org/users/{{unbound discourse}}">{{discourse}}</a></span></div>{{/if}}
     {{#if reddit}}<div class="row"><span class="key">reddit username</span><span class="value"><a href="http://www.reddit.com/user/{{unbound reddit}}">{{reddit}}</a></span></div>{{/if}}
     {{#if twitter}}<div class="row"><span class="key">twitter username</span><span class="value"><a href="https://twitter.com/{{unbound twitter}}">{{twitter}}</a></span></div>{{/if}}
     {{#if website}}<div class="row"><span class="key">website</span><span class="value"><a href="{{unbound website}}">{{website}}</a></span></div>{{/if}}

--- a/rustaceans.org/js/router.js
+++ b/rustaceans.org/js/router.js
@@ -49,7 +49,7 @@ Rustaceans.SearchRoute = Ember.Route.extend({
 
 Rustaceans.SpeakerRoute = Ember.Route.extend({
   model: function(params) {
-    return jQuery.getJSON('http://localhost:2345/speaker?for=' + params.needle).then(function(res) {
+    return jQuery.getJSON(API_URL + '/speaker?for=' + params.needle).then(function(res) {
       return { results: res };
     });
   }

--- a/rustaceans.org/js/router.js
+++ b/rustaceans.org/js/router.js
@@ -14,6 +14,10 @@ Rustaceans.Router.map(function() {
 });
 
 Rustaceans.Router.map(function() {
+  this.route('speaker', { path: 'speaker/:needle' });
+});
+
+Rustaceans.Router.map(function() {
   this.resource('random', { path: '/random' });
 });
 
@@ -43,11 +47,21 @@ Rustaceans.SearchRoute = Ember.Route.extend({
   }
 });
 
+Rustaceans.SpeakerRoute = Ember.Route.extend({
+  model: function(params) {
+    return jQuery.getJSON('http://localhost:2345/speaker?for=' + params.needle).then(function(res) {
+      return { results: res };
+    });
+  }
+});
 
 Rustaceans.ApplicationRoute = Ember.Route.extend({
   actions: {
     search: function(val) {
       this.transitionTo('search', val);
+    },
+    speaker: function(val) {
+      this.transitionTo('speaker', val);
     }
   }
 });

--- a/rustaceans.org/js/router.js
+++ b/rustaceans.org/js/router.js
@@ -1,6 +1,10 @@
+var API_URL = 'http://www.ncameron.org/rustaceans';
+//var API_URL = 'http://localhost:2345';
+
 Rustaceans.Router.map(function() {
   this.resource('index', { path: '/' });
 });
+
 Rustaceans.Router.map(function() {
   this.resource('index', { path: '/index.html' });
 });
@@ -19,7 +23,7 @@ Rustaceans.Router.map(function() {
 
 Rustaceans.PeopleRoute = Ember.Route.extend({
   model: function(params) {
-    return jQuery.getJSON('http://www.ncameron.org/rustaceans/user?username=' + params.username).then(function(res) {
+    return jQuery.getJSON(API_URL + '/user?username=' + params.username).then(function(res) {
       return { results: res };
     });
   },
@@ -33,7 +37,7 @@ Rustaceans.PeopleRoute = Ember.Route.extend({
 
 Rustaceans.SearchRoute = Ember.Route.extend({
   model: function(params) {
-    return jQuery.getJSON('http://www.ncameron.org/rustaceans/search?for=' + params.needle).then(function(res) {
+    return jQuery.getJSON(API_URL + '/search?for=' + params.needle).then(function(res) {
       return { results: res };
     });
   }
@@ -51,7 +55,7 @@ Rustaceans.ApplicationRoute = Ember.Route.extend({
 
 Rustaceans.RandomRoute = Ember.Route.extend({
   model: function(params) {
-    return jQuery.getJSON('http://www.ncameron.org/rustaceans/random').then(function(res) {
+    return jQuery.getJSON(API_URL + '/random').then(function(res) {
       return { results: res };
     });
   }


### PR DESCRIPTION
Most minimal solution to add speaker information & dedicated speaker search. [Screenshots in first comment](https://github.com/badboy/rustaceans-src/pull/3#issuecomment-270669546).

This adds the following new fields:

* speaker - Indiciating if the person is willing to speak
* speaker_topics - Topics a person could speak about
* location - A rough location of the person, currently just free text we search on

Contact can be done via GitHub, which links to a new issue like: <https://github.com/rust-community/talks/issues/new?title=[Speaker%20Request]%20&body=Hey+@user>
or via DM on urlo (Links to user)

Next step:

Turn it into a map like https://mte90.github.io/Tech-Speakers-Map/
We would need geolocation → either specific coordinates in the data or we map the location text to a geo location (easier for the user)